### PR TITLE
Add Kubernetes example using NodePort

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,41 @@ app.listen(9000, () => {
 ```
 
 **Note**: `require('appmetrics-zipkin')` should be included before requiring other packages to ensure those packages are correctly instrumented
+
+## Using Zipkin with Node.js and Kubernetes
+Deploy the Zipkin service with a given service name and exposure type, for example, naming the service `zipkin` and choosing to expose the service via the `NodePort` mechanism.
+
+Your Node.js code to send Zipkin traffic to the discovered server would be as follows:
+```
+var zipkinHost = "localhost"
+var zipkinPort = 9411  
+
+if (process.env.ZIPKIN_SERVICE_HOST && process.env.ZIPKIN_SERVICE_PORT) {
+  console.log("Routing Zipkin traffic to the Zipkin Kubernetes service")
+  zipkinHost = process.env.ZIPKIN_SERVICE_HOST
+  zipkinPort = process.env.ZIPKIN_SERVICE_PORT
+} else {
+  console.log("Detected we're running the Zipkin server locally")
+}
+
+var appzip = require('appmetrics-zipkin')({
+  host: zipkinHost
+  port: zipkinPort,
+  serviceName:'my-kube-frontend'
+});
+
+```
+
+You can see if the environment variables are present with the following commands
+
+`kubectl get pods` to discover the pod of your Zipkin deployment
+`kubectl exec -it *pod name* printenv | grep SERVICE`, e.g.
+
+```
+[Node.js@IBM icp-nodejs-sample]$ kubectl exec -it test-zipkin-289126497-pjf5b printenv | grep SERVICE
+ZIPKIN_SERVICE_HOST=10.0.0.105
+ZIPKIN_SERVICE_PORT=9411
+```
+
+
+

--- a/README.md
+++ b/README.md
@@ -58,7 +58,6 @@ var appzip = require('appmetrics-zipkin')({
   port: zipkinPort,
   serviceName:'my-kube-frontend'
 });
-
 ```
 
 You can see if the environment variables are present with the following commands
@@ -71,6 +70,3 @@ You can see if the environment variables are present with the following commands
 ZIPKIN_SERVICE_HOST=10.0.0.105
 ZIPKIN_SERVICE_PORT=9411
 ```
-
-
-

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ app.listen(9000, () => {
 });
 ```
 
-**Note**: `require('appmetrics-zipkin')` should be included before requiring other packages to ensure those packages are correctly instrumented
+**Note**: `require('appmetrics-zipkin')` must be included before requiring other packages to ensure those packages are correctly instrumented. Failure to do can result in spans not being sent to the Zipkin server.
 
 ## Using Zipkin with Node.js and Kubernetes
 Deploy the Zipkin service with a given service name and exposure type, for example, naming the service `zipkin` and choosing to expose the service via the `NodePort` mechanism.
@@ -60,7 +60,7 @@ var appzip = require('appmetrics-zipkin')({
 });
 ```
 
-You can see if the environment variables are present with the following commands
+You can see if the environment variables are present with the following commands:
 
 `kubectl get pods` to discover the pod of your Zipkin deployment
 `kubectl exec -it *pod name* printenv | grep SERVICE`, e.g.

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ if (process.env.ZIPKIN_SERVICE_HOST && process.env.ZIPKIN_SERVICE_PORT) {
 }
 
 var appzip = require('appmetrics-zipkin')({
-  host: zipkinHost
+  host: zipkinHost,
   port: zipkinPort,
   serviceName:'my-kube-frontend'
 });


### PR DESCRIPTION
This example covers how to use Zipkin with Node.js and Kubernetes - assumes one declares the Zipkin instance to be of type NodePort and with the service name "zipkin". 

Manual tests done using Kubernetes on IBM Cloud Private. I deployed an instance of Zipkin using "Microservice Builder" fabric. Expose it as type "NodePort" and for the Elasticsearch host I provided the pod IP (starting with `10.`).

With the sample I worked on [here](https://github.com/ibm-developer/icp-nodejs-sample) I can see spans at the Zipkin server for my endpoints.