### PR TITLE
Assign updated request object back to parameters.

### DIFF
--- a/probes/http-outbound-probe-zipkin.js
+++ b/probes/http-outbound-probe-zipkin.js
@@ -78,8 +78,8 @@ HttpOutboundProbeZipkin.prototype.attach = function(name, target) {
             requestMethod = parsedOptions.method;
           }
         }
-
-        Request.addZipkinHeaders(methodArgs[0], tracer.createChildId());
+        // Must assign new options back to methodArgs[0]
+        methodArgs[0] = Request.addZipkinHeaders(options, tracer.createChildId());
         tracer.recordServiceName(serviceName);
         tracer.recordRpc(requestMethod);
         tracer.recordBinary('http.url', urlRequested);

--- a/probes/http-probe-zipkin.js
+++ b/probes/http-probe-zipkin.js
@@ -112,7 +112,8 @@ HttpProbeZipkin.prototype.attach = function(name, target) {
             } else {
               tracer.setId(tracer.createRootId());
               probeData.traceId = tracer.id;
-              Request.addZipkinHeaders(args[0], tracer.id);
+              // Must assign new options back to args[0]
+              args[0] = Request.addZipkinHeaders(args[0], tracer.id);
             }
 
             tracer.recordServiceName(serviceName);

--- a/probes/https-outbound-probe-zipkin.js
+++ b/probes/https-outbound-probe-zipkin.js
@@ -78,8 +78,8 @@ HttpsOutboundProbeZipkin.prototype.attach = function(name, target) {
             requestMethod = parsedOptions.method;
           }
         }
-
-        Request.addZipkinHeaders(methodArgs[0], tracer.createChildId());
+        // Must assign new options back to methodArgs[0]
+        methodArgs[0] = Request.addZipkinHeaders(methodArgs[0], tracer.createChildId());
         tracer.recordServiceName(serviceName);
         tracer.recordRpc(requestMethod);
         tracer.recordBinary('http.url', urlRequested);

--- a/probes/https-probe-zipkin.js
+++ b/probes/https-probe-zipkin.js
@@ -112,7 +112,8 @@ HttpsProbeZipkin.prototype.attach = function(name, target) {
             } else {
               tracer.setId(tracer.createRootId());
               probeData.traceId = tracer.id;
-              Request.addZipkinHeaders(args[0], tracer.id);
+              // Must assign new options back to args[0]
+              args[0] = Request.addZipkinHeaders(args[0], tracer.id);
             }
 
             tracer.recordServiceName(serviceName);


### PR DESCRIPTION
The zipkin code returns a new object that should replace the original request object.

We've missed this until now because if the original request object has a headers field zipkin updates the original headers object before returning a new request object. However a request with no headers object causes it to create a new object which only gets assigned to the new request object it returns.