### PR TITLE
Set sampleRate to 1.0 and make it configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,21 +9,22 @@ Connecting to a [Zipkin](https://github.com/openzipkin/zipkin) endpoint is done 
 
 Alternatively, the hostname, port and service name (used by Zipkin to identify your application) can be added when including appmetrics-zipkin into your application:
 
-```
+```js
 var appzip = require('appmetrics-zipkin')({
   host: 'localhost',
   port: 9411,
-  serviceName:'frontend'
+  serviceName:'frontend',
+  sampleRate: 1.0
 });
 ```
 
 **Note**: The properties file has precedence over the inline settings
 
-If no configuration details are provided, the endpoint will be _localhost:9411_ and the serviceName will be set to the program name that requires appmetrics-zipkin.
+If no configuration details are provided, the endpoint will be _localhost:9411_, the serviceName will be set to the program name that requires appmetrics-zipkin and the sample rate will be 1.0 (100% of requests).
 
 
 ## Usage
-```
+```js
 var appzip = require('appmetrics-zipkin');
 var express = require('express');
 var app = express();
@@ -41,7 +42,8 @@ app.listen(9000, () => {
 Deploy the Zipkin service with a given service name and exposure type, for example, naming the service `zipkin` and choosing to expose the service via the `NodePort` mechanism.
 
 Your Node.js code to send Zipkin traffic to the discovered server would be as follows:
-```
+
+```js
 var zipkinHost = "localhost"
 var zipkinPort = 9411  
 
@@ -56,7 +58,8 @@ if (process.env.ZIPKIN_SERVICE_HOST && process.env.ZIPKIN_SERVICE_PORT) {
 var appzip = require('appmetrics-zipkin')({
   host: zipkinHost,
   port: zipkinPort,
-  serviceName:'my-kube-frontend'
+  serviceName:'my-kube-frontend',
+  sampleRate: 1.0
 });
 ```
 

--- a/appmetrics-zipkin.js
+++ b/appmetrics-zipkin.js
@@ -53,12 +53,13 @@ module.exports = function(options) {
 
 function start(options) {
   // Set up the zipkin
-  var host, port, serviceName;
+  var host, port, serviceName, sampleRate;
 
   if (options) {
     host = options['host'];
     port = options['port'];
     serviceName = options['serviceName'];
+    sampleRate = options['sampleRate'];
   }
 
   // Uses properties from file if present
@@ -68,6 +69,12 @@ function start(options) {
     }
     if (properties.get('port')) {
       port = properties.get('port');
+    }
+    if (properties.get('serviceName')) {
+      serviceName = properties.get('serviceName');
+    }
+    if (properties.get('sampleRate')) {
+      sampleRate = properties.get('sampleRate');
     }
   }
 
@@ -79,6 +86,9 @@ function start(options) {
   }
   if (!port) {
     port = 9411;
+  }
+  if (!sampleRate) {
+    sampleRate = 1.0
   }
 
   // Test if the host & port are valid

--- a/appmetrics-zipkin.properties
+++ b/appmetrics-zipkin.properties
@@ -1,2 +1,4 @@
 host=
 port=
+serviceName=
+sampleRate=

--- a/probes/http-outbound-probe-zipkin.js
+++ b/probes/http-outbound-probe-zipkin.js
@@ -50,7 +50,7 @@ HttpOutboundProbeZipkin.prototype.attach = function(name, target) {
   const tracer = new zipkin.Tracer({
     ctxImpl,
     recorder: this.recorder,
-    sampler: new zipkin.sampler.CountingSampler(0.01), // sample rate 0.01 will sample 1 % of all incoming requests
+    sampler: new zipkin.sampler.CountingSampler(this.config.sampleRate), // sample rate 0.01 will sample 1 % of all incoming requests
     traceId128Bit: true // to generate 128-bit trace IDs.
   });
   serviceName = this.serviceName;

--- a/probes/http-probe-zipkin.js
+++ b/probes/http-probe-zipkin.js
@@ -69,7 +69,7 @@ HttpProbeZipkin.prototype.attach = function(name, target) {
   const tracer = new zipkin.Tracer({
     ctxImpl,
     recorder: this.recorder,
-    sampler: new zipkin.sampler.CountingSampler(0.01), // sample rate 0.01 will sample 1 % of all incoming requests
+    sampler: new zipkin.sampler.CountingSampler(this.config.sampleRate), // sample rate 0.01 will sample 1 % of all incoming requests
     traceId128Bit: true // to generate 128-bit trace IDs.
   });
 

--- a/probes/https-outbound-probe-zipkin.js
+++ b/probes/https-outbound-probe-zipkin.js
@@ -50,7 +50,7 @@ HttpsOutboundProbeZipkin.prototype.attach = function(name, target) {
   const tracer = new zipkin.Tracer({
     ctxImpl,
     recorder: this.recorder,
-    sampler: new zipkin.sampler.CountingSampler(0.01), // sample rate 0.01 will sample 1 % of all incoming requests
+    sampler: new zipkin.sampler.CountingSampler(this.config.sampleRate), // sample rate 0.01 will sample 1 % of all incoming requests
     traceId128Bit: true // to generate 128-bit trace IDs.
   });
   serviceName = this.serviceName;

--- a/probes/https-probe-zipkin.js
+++ b/probes/https-probe-zipkin.js
@@ -69,7 +69,7 @@ HttpsProbeZipkin.prototype.attach = function(name, target) {
   const tracer = new zipkin.Tracer({
     ctxImpl,
     recorder: this.recorder,
-    sampler: new zipkin.sampler.CountingSampler(0.01), // sample rate 0.01 will sample 1 % of all incoming requests
+    sampler: new zipkin.sampler.CountingSampler(this.config.sampleRate), // sample rate 0.01 will sample 1 % of all incoming requests
     traceId128Bit: true // to generate 128-bit trace IDs.
   });
 


### PR DESCRIPTION
Currently the sample rate is set to 0.01 (1%), and it not configurable. When you use an application with appmetrics-zipkin, the effect of this is that every span is reported, but we only propagate the request ID in the headers in 1% of cases.

For the majority of cases I would expect that you'd want to propagate in every case, and then tune down for performance if required.

This sets the default to 1.0, and makes it possible to configure through either passing in an option at startup, or through the properties file.