### PR TITLE
Modify only an incoming request's headers

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -4,3 +4,4 @@ Authors ordered by first contribution
  - Julie Stalley (julie_stalley@uk.ibm.com)
  - Aaron Collins (aaron.collins1@ibm.com)
  - Chris Bailey (BAILEYC@uk.ibm.com)
+ - Eli Goldberg (eli.b.goldberg@gmail.com)

--- a/probes/http-probe-zipkin.js
+++ b/probes/http-probe-zipkin.js
@@ -113,7 +113,8 @@ HttpProbeZipkin.prototype.attach = function(name, target) {
               tracer.setId(tracer.createRootId());
               probeData.traceId = tracer.id;
               // Must assign new options back to args[0]
-              args[0] = Request.addZipkinHeaders(args[0], tracer.id);
+              const { headers } = Request.addZipkinHeaders(args[0], tracer.id);
+              Object.assign(args[0].headers, headers);
             }
 
             tracer.recordServiceName(serviceName);


### PR DESCRIPTION
addZipkinHeaders returns a copy of the request object (which is a node IncomingMessage object),
which causes the object to lose it's Event methods, e.g. _req.on('data')_.
This causes modules such as koa-bodyparser to crash, because it relies on the request to have those methods.